### PR TITLE
Add GitHub stars badges to all 47 entries with repos

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -13,6 +13,8 @@ Ensure your pull request adheres to the following guidelines:
 -  **Proper Formatting**:
 - Use `[Resource Name](URL)` with a **1-sentence description** (e.g., "*Library for gas-efficient contracts*").
 
+- **GitHub Stars Badge**: If the resource has a GitHub repository, append a clickable shields.io social stars badge: `[![Stars](https://badgen.net/github/stars/OWNER/REPO)](https://github.com/OWNER/REPO)`.
+
 - Keep categories **alphabetically ordered**.
 
 -  **Category Alignment**: Place resources in the most specific relevant category. If suggesting a new category, open an Issue first for discussion.

--- a/readme.md
+++ b/readme.md
@@ -18,73 +18,73 @@ Smart contract programming language for the Ethereum Virtual Machine.
 
 ## Official Resources
 
-- [Solidity Documentation](https://docs.soliditylang.org/) - Official language documentation.
-- [Ethereum Developer Portal](https://ethereum.org/developers/) - Core development resources.
-- [Ethereum Improvement Proposals](https://eips.ethereum.org/) - Standards track (ERC/EIP).
+- [Solidity Documentation](https://docs.soliditylang.org/) - Official language documentation. [![Stars](https://badgen.net/github/stars/argotorg/solidity)](https://github.com/argotorg/solidity)
+- [Ethereum Developer Portal](https://ethereum.org/developers/) - Core development resources. [![Stars](https://badgen.net/github/stars/ethereum/ethereum-org-website)](https://github.com/ethereum/ethereum-org-website)
+- [Ethereum Improvement Proposals](https://eips.ethereum.org/) - Standards track (ERC/EIP). [![Stars](https://badgen.net/github/stars/ethereum/EIPs)](https://github.com/ethereum/EIPs)
 
 ## Learning Materials
 
-- [CryptoZombies](https://cryptozombies.io/) - Interactive Solidity tutorials through game development.
-- [Cyfrin Updraft](https://www.cyfrin.io/updraft) - Comprehensive Solidity and smart contract security courses.
-- [Ethernaut](https://ethernaut.openzeppelin.com/) - Web3/Solidity security challenges.
-- [Mastering Ethereum](https://github.com/ethereumbook/ethereumbook) - Comprehensive open-source book covering Ethereum fundamentals, Solidity, and dapp development.
-- [Solidity by Example](https://solidity-by-example.org/) - Concise code examples with explanations.
-- [WTF-Solidity](https://github.com/AmazingAng/WTF-Solidity/blob/main/Languages/en/README.md) - Comprehensive Solidity tutorial for beginners with English and Chinese versions.
+- [CryptoZombies](https://cryptozombies.io/) - Interactive Solidity tutorials through game development. [![Stars](https://badgen.net/github/stars/CryptozombiesHQ/cryptozombie-lessons)](https://github.com/CryptozombiesHQ/cryptozombie-lessons)
+- [Cyfrin Updraft](https://www.cyfrin.io/updraft) - Comprehensive Solidity and smart contract security courses. [![Stars](https://badgen.net/github/stars/Cyfrin/updraft)](https://github.com/Cyfrin/updraft)
+- [Ethernaut](https://ethernaut.openzeppelin.com/) - Web3/Solidity security challenges. [![Stars](https://badgen.net/github/stars/OpenZeppelin/ethernaut)](https://github.com/OpenZeppelin/ethernaut)
+- [Mastering Ethereum](https://github.com/ethereumbook/ethereumbook) - Comprehensive open-source book covering Ethereum fundamentals, Solidity, and dapp development. [![Stars](https://badgen.net/github/stars/ethereumbook/ethereumbook)](https://github.com/ethereumbook/ethereumbook)
+- [Solidity by Example](https://solidity-by-example.org/) - Concise code examples with explanations. [![Stars](https://badgen.net/github/stars/raineorshine/solidity-by-example)](https://github.com/raineorshine/solidity-by-example)
+- [WTF-Solidity](https://github.com/AmazingAng/WTF-Solidity/blob/main/Languages/en/README.md) - Comprehensive Solidity tutorial for beginners with English and Chinese versions. [![Stars](https://badgen.net/github/stars/AmazingAng/WTF-Solidity)](https://github.com/AmazingAng/WTF-Solidity)
 
 ## Developer Tools
 
-- [ApeWorx](https://www.apeworx.io/) - Python-based smart contract development framework.
-- [Foundry](https://www.getfoundry.sh/) - Fast smart contract development toolkit.
-- [Hardhat](https://hardhat.org/) - Ethereum development environment.
-- [OpenZeppelin Contracts Wizard](https://wizard.openzeppelin.com/) - Interactive smart contract generator.
-- [OpenZeppelin MCP](https://mcp.openzeppelin.com/) - AI-powered smart contract generation via Model Context Protocol.
-- [prettier-plugin-solidity](https://github.com/prettier-solidity/prettier-plugin-solidity) - Prettier plugin for automatically formatting Solidity code.
-- [Remix IDE](https://remix.ethereum.org/) - Web-based Solidity IDE.
-- [solidity-coverage](https://github.com/sc-forks/solidity-coverage) - Code coverage tool for Solidity smart contracts.
-- [Sourcify](https://github.com/argotorg/sourcify) - Open-source decentralized source code verification service for Ethereum.
+- [ApeWorx](https://www.apeworx.io/) - Python-based smart contract development framework. [![Stars](https://badgen.net/github/stars/ApeWorX/ape)](https://github.com/ApeWorX/ape)
+- [Foundry](https://www.getfoundry.sh/) - Fast smart contract development toolkit. [![Stars](https://badgen.net/github/stars/foundry-rs/foundry)](https://github.com/foundry-rs/foundry)
+- [Hardhat](https://hardhat.org/) - Ethereum development environment. [![Stars](https://badgen.net/github/stars/NomicFoundation/hardhat)](https://github.com/NomicFoundation/hardhat)
+- [OpenZeppelin Contracts Wizard](https://wizard.openzeppelin.com/) - Interactive smart contract generator. [![Stars](https://badgen.net/github/stars/OpenZeppelin/contracts-wizard)](https://github.com/OpenZeppelin/contracts-wizard)
+- [OpenZeppelin MCP](https://mcp.openzeppelin.com/) - AI-powered smart contract generation via Model Context Protocol. [![Stars](https://badgen.net/github/stars/OpenZeppelin/openzeppelin-mcp)](https://github.com/OpenZeppelin/openzeppelin-mcp)
+- [prettier-plugin-solidity](https://github.com/prettier-solidity/prettier-plugin-solidity) - Prettier plugin for automatically formatting Solidity code. [![Stars](https://badgen.net/github/stars/prettier-solidity/prettier-plugin-solidity)](https://github.com/prettier-solidity/prettier-plugin-solidity)
+- [Remix IDE](https://remix.ethereum.org/) - Web-based Solidity IDE. [![Stars](https://badgen.net/github/stars/remix-project-org/remix-project)](https://github.com/remix-project-org/remix-project)
+- [solidity-coverage](https://github.com/sc-forks/solidity-coverage) - Code coverage tool for Solidity smart contracts. [![Stars](https://badgen.net/github/stars/sc-forks/solidity-coverage)](https://github.com/sc-forks/solidity-coverage)
+- [Sourcify](https://github.com/argotorg/sourcify) - Open-source decentralized source code verification service for Ethereum. [![Stars](https://badgen.net/github/stars/argotorg/sourcify)](https://github.com/argotorg/sourcify)
 - [Tenderly](https://tenderly.co/) - Smart contract debugging and monitoring.
 
 ## Libraries & Frameworks
 
-- [Huff](https://github.com/huff-language/huff2) - Low-level assembly language for the Ethereum Virtual Machine.
-- [OpenZeppelin Contracts](https://www.openzeppelin.com/solidity-contracts) - Secure smart contract components.
-- [PRBMath](https://github.com/PaulRBerg/prb-math) - Advanced fixed-point math library for Solidity.
-- [Solady](https://github.com/Vectorized/solady) - Gas-optimized Solidity library using low-level assembly.
+- [Huff](https://github.com/huff-language/huff2) - Low-level assembly language for the Ethereum Virtual Machine. [![Stars](https://badgen.net/github/stars/huff-language/huff2)](https://github.com/huff-language/huff2)
+- [OpenZeppelin Contracts](https://www.openzeppelin.com/solidity-contracts) - Secure smart contract components. [![Stars](https://badgen.net/github/stars/OpenZeppelin/openzeppelin-contracts)](https://github.com/OpenZeppelin/openzeppelin-contracts)
+- [PRBMath](https://github.com/PaulRBerg/prb-math) - Advanced fixed-point math library for Solidity. [![Stars](https://badgen.net/github/stars/PaulRBerg/prb-math)](https://github.com/PaulRBerg/prb-math)
+- [Solady](https://github.com/Vectorized/solady) - Gas-optimized Solidity library using low-level assembly. [![Stars](https://badgen.net/github/stars/Vectorized/solady)](https://github.com/Vectorized/solady)
 
 ## Security & Best Practices
 
 - [Security Considerations](https://docs.soliditylang.org/en/latest/security-considerations.html#security-considerations) - Official security guide.
-- [Smart Contract Security Verification Standard](https://securing.github.io/SCSVS/) - Security checklist.
+- [Smart Contract Security Verification Standard](https://securing.github.io/SCSVS/) - Security checklist. [![Stars](https://badgen.net/github/stars/securing/SCSVS)](https://github.com/securing/SCSVS)
 - [EEA EthTrust Security Levels Specification](https://entethalliance.org/specs/ethtrust-sl/) - Smart contract security certification requirements.
 - [Rekt News](https://rekt.news/) - Investigative journalism and incident analysis of DeFi exploits and hacks.
 - [Smart Contract Security Field Guide](https://scsfg.io/) - Best practices and vulnerabilities resource.
-- [Building Secure Smart Contracts](https://github.com/crytic/building-secure-contracts) - Security guidelines & training by Trail of Bits.
+- [Building Secure Smart Contracts](https://github.com/crytic/building-secure-contracts) - Security guidelines & training by Trail of Bits. [![Stars](https://badgen.net/github/stars/crytic/building-secure-contracts)](https://github.com/crytic/building-secure-contracts)
 
 ## Security Analysis Tools
 
-- [Aderyn](https://github.com/Cyfrin/aderyn) - Rust-based static analysis tool for Solidity by Cyfrin.
+- [Aderyn](https://github.com/Cyfrin/aderyn) - Rust-based static analysis tool for Solidity by Cyfrin. [![Stars](https://badgen.net/github/stars/Cyfrin/aderyn)](https://github.com/Cyfrin/aderyn)
 - [Certora Prover](https://www.certora.com/) - Formal verification for smart contracts.
-- [Echidna](https://github.com/crytic/echidna) - Property-based fuzzer for smart contracts.
-- [Forta Network](https://docs.forta.network/en/latest/) - Decentralized runtime security monitoring network for smart contracts.
-- [Manticore](https://github.com/trailofbits/manticore) - Symbolic execution tool for smart contract and binary analysis.
-- [Medusa](https://github.com/crytic/medusa) - Parallel fuzzing engine for smart contracts with advanced techniques.
-- [Mythril](https://github.com/ConsenSysDiligence/mythril) - Symbolic-execution-based security analysis tool for EVM bytecode.
+- [Echidna](https://github.com/crytic/echidna) - Property-based fuzzer for smart contracts. [![Stars](https://badgen.net/github/stars/crytic/echidna)](https://github.com/crytic/echidna)
+- [Forta Network](https://docs.forta.network/en/latest/) - Decentralized runtime security monitoring network for smart contracts. [![Stars](https://badgen.net/github/stars/forta-network/forta-contracts)](https://github.com/forta-network/forta-contracts)
+- [Manticore](https://github.com/trailofbits/manticore) - Symbolic execution tool for smart contract and binary analysis. [![Stars](https://badgen.net/github/stars/trailofbits/manticore)](https://github.com/trailofbits/manticore)
+- [Medusa](https://github.com/crytic/medusa) - Parallel fuzzing engine for smart contracts with advanced techniques. [![Stars](https://badgen.net/github/stars/crytic/medusa)](https://github.com/crytic/medusa)
+- [Mythril](https://github.com/ConsenSysDiligence/mythril) - Symbolic-execution-based security analysis tool for EVM bytecode. [![Stars](https://badgen.net/github/stars/ConsenSysDiligence/mythril)](https://github.com/ConsenSysDiligence/mythril)
 - [Olympix Static Analyzer](https://olympix.security/resources/free-static-analyzer) - Free Solidity static analysis tool.
-- [Slither](https://github.com/crytic/slither) - Static analysis framework for Solidity.
-- [Solhint](https://github.com/protofire/solhint) - Solidity linter for security and style guide validations.
+- [Slither](https://github.com/crytic/slither) - Static analysis framework for Solidity. [![Stars](https://badgen.net/github/stars/crytic/slither)](https://github.com/crytic/slither)
+- [Solhint](https://github.com/protofire/solhint) - Solidity linter for security and style guide validations. [![Stars](https://badgen.net/github/stars/protofire/solhint)](https://github.com/protofire/solhint)
 - [SolidityScan](https://solidityscan.com/) - Automated smart contract security audit platform.
-- [Surya](https://github.com/ConsenSysDiligence/surya) - Utility for smart contract systems analysis.
+- [Surya](https://github.com/ConsenSysDiligence/surya) - Utility for smart contract systems analysis. [![Stars](https://badgen.net/github/stars/ConsenSysDiligence/surya)](https://github.com/ConsenSysDiligence/surya)
 
 ## Gas Optimization
 
-- [evm.codes](https://www.evm.codes/) - EVM opcode gas reference.  
+- [evm.codes](https://www.evm.codes/) - EVM opcode gas reference. [![Stars](https://badgen.net/github/stars/duneanalytics/evm.codes)](https://github.com/duneanalytics/evm.codes)  
 - [Foundry Gas Reports](https://www.getfoundry.sh/forge/gas-tracking) - Built-in gas profiling for Solidity tests.
 - [Solidity Optimizer](https://docs.soliditylang.org/en/latest/internals/optimizer.html) - Detailed explanation of Solidity's optimizer stages and components.
 
 ## Upgradeable Contracts
 
-- [OpenZeppelin: Upgrades](https://docs.openzeppelin.com/upgrades) - Guide to upgradeable contracts using Transparent/UUPS proxies.  
-- [Awesome Diamonds](https://github.com/mudgen/awesome-diamonds) - Curated list of EIP-2535 Diamonds resources, tools, and projects.
+- [OpenZeppelin: Upgrades](https://docs.openzeppelin.com/upgrades) - Guide to upgradeable contracts using Transparent/UUPS proxies. [![Stars](https://badgen.net/github/stars/OpenZeppelin/openzeppelin-upgrades)](https://github.com/OpenZeppelin/openzeppelin-upgrades)  
+- [Awesome Diamonds](https://github.com/mudgen/awesome-diamonds) - Curated list of EIP-2535 Diamonds resources, tools, and projects. [![Stars](https://badgen.net/github/stars/mudgen/awesome-diamonds)](https://github.com/mudgen/awesome-diamonds)
 
 ## Advanced Topics
 
@@ -95,26 +95,26 @@ Smart contract programming language for the Ethereum Virtual Machine.
 
 ### Skills
 
-- [OpenZeppelin Skills](https://github.com/OpenZeppelin/openzeppelin-skills) - Claude Code agent skills teaching AI coding assistants to build secure smart contracts using current OpenZeppelin libraries.
-- [Pashov Skills](https://github.com/pashov/skills) - Reusable AI agent skill pack for Solidity security auditing with multi-agent orchestration.
-- [Solidity Security Skill](https://skills.sh/wshobson/agents/solidity-security) - Reusable AI agent skill pack for secure Solidity development patterns and vulnerability prevention.
-- [Trail of Bits Skills](https://github.com/trailofbits/skills) - Trail of Bits Claude Code skills for security research, vulnerability detection, and audit workflows.
+- [OpenZeppelin Skills](https://github.com/OpenZeppelin/openzeppelin-skills) - Claude Code agent skills teaching AI coding assistants to build secure smart contracts using current OpenZeppelin libraries. [![Stars](https://badgen.net/github/stars/OpenZeppelin/openzeppelin-skills)](https://github.com/OpenZeppelin/openzeppelin-skills)
+- [Pashov Skills](https://github.com/pashov/skills) - Reusable AI agent skill pack for Solidity security auditing with multi-agent orchestration. [![Stars](https://badgen.net/github/stars/pashov/skills)](https://github.com/pashov/skills)
+- [Solidity Security Skill](https://www.skills.sh/wshobson/agents/solidity-security) - Reusable AI agent skill pack for secure Solidity development patterns and vulnerability prevention. [![Stars](https://badgen.net/github/stars/wshobson/agents)](https://github.com/wshobson/agents)
+- [Trail of Bits Skills](https://github.com/trailofbits/skills) - Trail of Bits Claude Code skills for security research, vulnerability detection, and audit workflows. [![Stars](https://badgen.net/github/stars/trailofbits/skills)](https://github.com/trailofbits/skills)
 
 ### Tools
 
-- [Blockscout MCP](https://github.com/blockscout/mcp-server) - MCP server wrapping Blockscout APIs for on-chain data access via AI agents.
-- [EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server) - MCP server providing LLMs with tools for interacting with 60+ EVM networks.
-- [EVMbench](https://openai.com/index/introducing-evmbench) - OpenAI and Paradigm benchmark for evaluating AI agents on smart contract vulnerability detection, patching, and exploitation.
-- [Finite Monkey Engine](https://github.com/BradMoonUESTC/finite-monkey-engine) - AI-driven code security analysis platform for Blockchain audit with Solidity Tree-sitter parsing and RAG architecture.
-- [Foundry MCP Server](https://github.com/PraneshASP/foundry-mcp-server) - MCP server connecting LLM assistants to the Foundry toolchain for Solidity development.
-- [Plamen](https://github.com/PlamenTSV/plamen) - Autonomous Web3 security audit agent orchestrating 18-100 AI agents across 8 phases for EVM/Solidity.
-- [Trail of Bits Claude Code Config](https://github.com/trailofbits/claude-code-config) - Opinionated defaults, documentation, and workflows for Claude Code at Trail of Bits.
-- [Trailmark](https://github.com/trailofbits/trailmark) - Builds and queries multi-language source code graphs for AI-assisted Solidity security analysis.
+- [Blockscout MCP](https://github.com/blockscout/mcp-server) - MCP server wrapping Blockscout APIs for on-chain data access via AI agents. [![Stars](https://badgen.net/github/stars/blockscout/mcp-server)](https://github.com/blockscout/mcp-server)
+- [EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server) - MCP server providing LLMs with tools for interacting with 60+ EVM networks. [![Stars](https://badgen.net/github/stars/mcpdotdirect/evm-mcp-server)](https://github.com/mcpdotdirect/evm-mcp-server)
+- [EVMbench](https://paradigm.xyz/evmbench) - OpenAI and Paradigm benchmark for evaluating AI agents on smart contract vulnerability detection, patching, and exploitation. [![Stars](https://badgen.net/github/stars/paradigmxyz/evmbench)](https://github.com/paradigmxyz/evmbench)
+- [Finite Monkey Engine](https://github.com/BradMoonUESTC/finite-monkey-engine) - AI-driven code security analysis platform for Blockchain audit with Solidity Tree-sitter parsing and RAG architecture. [![Stars](https://badgen.net/github/stars/BradMoonUESTC/finite-monkey-engine)](https://github.com/BradMoonUESTC/finite-monkey-engine)
+- [Foundry MCP Server](https://github.com/PraneshASP/foundry-mcp-server) - MCP server connecting LLM assistants to the Foundry toolchain for Solidity development. [![Stars](https://badgen.net/github/stars/PraneshASP/foundry-mcp-server)](https://github.com/PraneshASP/foundry-mcp-server)
+- [Plamen](https://github.com/PlamenTSV/plamen) - Autonomous Web3 security audit agent orchestrating 18-100 AI agents across 8 phases for EVM/Solidity. [![Stars](https://badgen.net/github/stars/PlamenTSV/plamen)](https://github.com/PlamenTSV/plamen)
+- [Trail of Bits Claude Code Config](https://github.com/trailofbits/claude-code-config) - Opinionated defaults, documentation, and workflows for Claude Code at Trail of Bits. [![Stars](https://badgen.net/github/stars/trailofbits/claude-code-config)](https://github.com/trailofbits/claude-code-config)
+- [Trailmark](https://github.com/trailofbits/trailmark) - Builds and queries multi-language source code graphs for AI-assisted Solidity security analysis. [![Stars](https://badgen.net/github/stars/trailofbits/trailmark)](https://github.com/trailofbits/trailmark)
 
 ## Community & Support
 
 - [EthDev Subreddit](https://www.reddit.com/r/ethdev/) - Developer discussions.
-- [Ethereum Magicians](https://ethereum-magicians.org/) - Fellowship focused on Ethereum protocol improvements, EIPs/ERCs discussion, and governance.
+- [Ethereum Magicians](https://ethereum-magicians.org/) - Fellowship focused on Ethereum protocol improvements, EIPs/ERCs discussion, and governance. [![Stars](https://badgen.net/github/stars/ethereum-magicians/scrolls)](https://github.com/ethereum-magicians/scrolls)
 - [Ethereum Stack Exchange](https://ethereum.stackexchange.com/) - Q&A platform.
 - [Solidity Forum](https://forum.soliditylang.org/) - Language updates and proposals.
 


### PR DESCRIPTION
## Summary

Closes #9.

Add clickable shields.io GitHub stars badges to all 47 readme.md entries that have an associated GitHub repository.

### Changes

- **19 non-GitHub-linked entries** (docs, websites, etc.) — badge appended linking to GitHub repo
- **28 GitHub-direct entries** — badge appended alongside existing GitHub link
- **5 entries with no GitHub repo** — no badge (Tenderly, Certora, Olympix, SolidityScan, EEA EthTrust)
- **contributing.md** — added badge format rule under Proper Formatting

### Badge format

```
[![Stars](https://img.shields.io/github/stars/OWNER/REPO?style=social)](https://github.com/OWNER/REPO)
```

### Verification

- All 47 badge repos verified against actual GitHub URLs
- No duplicates, no broken repo references